### PR TITLE
Feat: #30 jump on top of object jump again

### DIFF
--- a/Assets/Dev/Si Wai/JumpOnObject.unity
+++ b/Assets/Dev/Si Wai/JumpOnObject.unity
@@ -294,7 +294,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 9169223613212550927, guid: f39688a7a7366934c95fc24f9dd976ea, type: 3}
       propertyPath: jumpForce
-      value: 5
+      value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 9169223613212550927, guid: f39688a7a7366934c95fc24f9dd976ea, type: 3}
       propertyPath: m_Enabled
@@ -411,13 +411,13 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1895656751}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: 0.34152752, w: 0.9398718}
   m_LocalPosition: {x: 2.61, y: 0.5314, z: -0.5}
   m_LocalScale: {x: 1, y: 0.6114, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 39.94}
 --- !u!114 &1895656756
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -430,8 +430,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a0ac98e4f916186468307f45a275d0c5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  bounceForceUp: 5
-  bounceForceForward: 0.1
+  bounceForceUp: 10
+  bounceForceForward: 0
   topAngleThreshold: 105
 --- !u!1 &1968757622
 GameObject:

--- a/Assets/Dev/Si Wai/JumpOnObject.unity
+++ b/Assets/Dev/Si Wai/JumpOnObject.unity
@@ -293,11 +293,16 @@ PrefabInstance:
       value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 9169223613212550927, guid: f39688a7a7366934c95fc24f9dd976ea, type: 3}
+      propertyPath: jumpForce
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 9169223613212550927, guid: f39688a7a7366934c95fc24f9dd976ea, type: 3}
       propertyPath: m_Enabled
       value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 7381533430093062579, guid: f39688a7a7366934c95fc24f9dd976ea, type: 3}
+    - {fileID: 4926589023627480149, guid: f39688a7a7366934c95fc24f9dd976ea, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -314,6 +319,7 @@ GameObject:
   - component: {fileID: 1895656754}
   - component: {fileID: 1895656753}
   - component: {fileID: 1895656752}
+  - component: {fileID: 1895656756}
   m_Layer: 0
   m_Name: Capsule
   m_TagString: Untagged
@@ -412,6 +418,21 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1895656756
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1895656751}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a0ac98e4f916186468307f45a275d0c5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  bounceForceUp: 5
+  bounceForceForward: 0.1
+  topAngleThreshold: 105
 --- !u!1 &1968757622
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Dev/Si Wai/JumpOnObject.unity
+++ b/Assets/Dev/Si Wai/JumpOnObject.unity
@@ -228,134 +228,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &329359280 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 6841058461259160835, guid: f39688a7a7366934c95fc24f9dd976ea, type: 3}
-  m_PrefabInstance: {fileID: 1142733713}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &329359287
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 329359280}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: da7430b38fabe854bb44c924a4893d76, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  player: {fileID: 1393146272}
---- !u!1 &643598491
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 643598495}
-  - component: {fileID: 643598494}
-  - component: {fileID: 643598493}
-  - component: {fileID: 643598492}
-  m_Layer: 0
-  m_Name: Capsule
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!136 &643598492
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 643598491}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Radius: 0.5
-  m_Height: 2
-  m_Direction: 1
-  m_Center: {x: 0, y: 0, z: 0}
---- !u!23 &643598493
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 643598491}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!33 &643598494
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 643598491}
-  m_Mesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
---- !u!4 &643598495
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 643598491}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 3.47, y: 0.5573, z: 2.88}
-  m_LocalScale: {x: 1, y: 0.5473, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1142733713
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -418,7 +290,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 9169223613212550927, guid: f39688a7a7366934c95fc24f9dd976ea, type: 3}
       propertyPath: speed
-      value: 7
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 9169223613212550927, guid: f39688a7a7366934c95fc24f9dd976ea, type: 3}
       propertyPath: m_Enabled
@@ -426,25 +298,120 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 7381533430093062579, guid: f39688a7a7366934c95fc24f9dd976ea, type: 3}
-    - {fileID: 4926589023627480149, guid: f39688a7a7366934c95fc24f9dd976ea, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 6841058461259160835, guid: f39688a7a7366934c95fc24f9dd976ea, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 329359287}
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f39688a7a7366934c95fc24f9dd976ea, type: 3}
---- !u!114 &1393146272 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 9169223613212550927, guid: f39688a7a7366934c95fc24f9dd976ea, type: 3}
-  m_PrefabInstance: {fileID: 1142733713}
+--- !u!1 &1895656751
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1895656755}
+  - component: {fileID: 1895656754}
+  - component: {fileID: 1895656753}
+  - component: {fileID: 1895656752}
+  m_Layer: 0
+  m_Name: Capsule
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!136 &1895656752
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1895656751}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
   m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c8727f22fc89cd54b9e87543dfb8dca6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Height: 2
+  m_Direction: 1
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &1895656753
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1895656751}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1895656754
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1895656751}
+  m_Mesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1895656755
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1895656751}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 2.61, y: 0.5314, z: -0.5}
+  m_LocalScale: {x: 1, y: 0.6114, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1968757622
 GameObject:
   m_ObjectHideFlags: 0
@@ -573,4 +540,4 @@ SceneRoots:
   - {fileID: 1968757624}
   - {fileID: 202999002}
   - {fileID: 1142733713}
-  - {fileID: 643598495}
+  - {fileID: 1895656755}

--- a/Assets/Dev/Si Wai/JumpOnObject.unity.meta
+++ b/Assets/Dev/Si Wai/JumpOnObject.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e725ecbf09ea6ae43a3c31767dcffcc3
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Dev/Si Wai/JumpingMovement.cs
+++ b/Assets/Dev/Si Wai/JumpingMovement.cs
@@ -1,0 +1,24 @@
+using UnityEngine;
+
+public class JumpingMovement : MonoBehaviour
+{
+    public float bounceForceUp = 5.0f;
+    public float bounceForceForward = 0.1f;
+    public float topAngleThreshold = 105.0f;
+    
+    void OnCollisionEnter(Collision collision)  {
+        Rigidbody rb = collision.gameObject.GetComponent<Rigidbody>();
+        if (rb) {
+            foreach (ContactPoint contact in collision.contacts) {
+                float angle = Vector3.Angle(contact.normal, Vector3.up);
+                
+                // if an object gets on top of the object this script is attached to
+                if (angle >= topAngleThreshold) {
+                    rb.linearVelocity = new Vector3(rb.linearVelocity.x, 0, rb.linearVelocity.z);
+                    rb.AddForce(Vector3.up * bounceForceUp +  rb.transform.forward * bounceForceForward, ForceMode.Impulse); // bounce effect
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/Assets/Dev/Si Wai/JumpingMovement.cs
+++ b/Assets/Dev/Si Wai/JumpingMovement.cs
@@ -6,8 +6,10 @@ public class JumpingMovement : MonoBehaviour
     public float bounceForceForward = 0.1f;
     public float topAngleThreshold = 105.0f;
     
-    void OnCollisionEnter(Collision collision)  {
-        Rigidbody rb = collision.gameObject.GetComponent<Rigidbody>();
+    void OnCollisionEnter(Collision collision)
+    {
+        Rigidbody rb = collision.rigidbody;
+        
         if (rb) {
             foreach (ContactPoint contact in collision.contacts) {
                 float angle = Vector3.Angle(contact.normal, Vector3.up);
@@ -15,7 +17,7 @@ public class JumpingMovement : MonoBehaviour
                 // if an object gets on top of the object this script is attached to
                 if (angle >= topAngleThreshold) {
                     rb.linearVelocity = new Vector3(rb.linearVelocity.x, 0, rb.linearVelocity.z);
-                    rb.AddForce(Vector3.up * bounceForceUp +  rb.transform.forward * bounceForceForward, ForceMode.Impulse); // bounce effect
+                    rb.AddForce(transform.up * bounceForceUp +  rb.transform.forward * bounceForceForward, ForceMode.Impulse); // bounce effect
                     break;
                 }
             }

--- a/Assets/Dev/Si Wai/JumpingMovement.cs.meta
+++ b/Assets/Dev/Si Wai/JumpingMovement.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a0ac98e4f916186468307f45a275d0c5

--- a/Assets/Global/Scripts/Player/PlayerObject.cs
+++ b/Assets/Global/Scripts/Player/PlayerObject.cs
@@ -1,10 +1,23 @@
 using UnityEngine;
-using UnityEngine.Serialization;
 
 public class PlayerObject : MonoBehaviour
 {
     public Player player;
-    private void OnCollisionEnter(Collision collision) => player.OnCollisionEnter(collision);
-
-    private void OnCollisionExit(Collision collision) => player.OnCollisionExit(collision);
+    void OnCollisionEnter(Collision collision)  {
+        float groundCheckAngle = 60f;
+        if (!collision.gameObject.CompareTag("Ground")) { // if the player touches something that is not the ground
+            foreach (ContactPoint contact in collision.contacts) {
+                float angle = Vector3.Angle(contact.normal, Vector3.up);
+                
+                if (angle <= groundCheckAngle) { // if players jumps on top of it
+                    player.rb.linearVelocity = new Vector3(player.rb.linearVelocity.x, 0, player.rb.linearVelocity.z);
+                    player.rb.AddForce(Vector3.up * player.jumpForce +  Vector3.forward * 2.0f, ForceMode.Impulse); // made the player jump again after touching
+                    break;
+                }
+            }
+        }
+        player.OnCollisionEnter(collision);
+    }
+    
+    void OnCollisionExit(Collision collision) => player.OnCollisionExit(collision);
 }

--- a/Assets/Global/Scripts/Player/PlayerObject.cs
+++ b/Assets/Global/Scripts/Player/PlayerObject.cs
@@ -3,21 +3,7 @@ using UnityEngine;
 public class PlayerObject : MonoBehaviour
 {
     public Player player;
-    void OnCollisionEnter(Collision collision)  {
-        float groundCheckAngle = 60f;
-        if (!collision.gameObject.CompareTag("Ground")) { // if the player touches something that is not the ground
-            foreach (ContactPoint contact in collision.contacts) {
-                float angle = Vector3.Angle(contact.normal, Vector3.up);
-                
-                if (angle <= groundCheckAngle) { // if players jumps on top of it
-                    player.rb.linearVelocity = new Vector3(player.rb.linearVelocity.x, 0, player.rb.linearVelocity.z);
-                    player.rb.AddForce(Vector3.up * player.jumpForce +  Vector3.forward * 2.0f, ForceMode.Impulse); // made the player jump again after touching
-                    break;
-                }
-            }
-        }
-        player.OnCollisionEnter(collision);
-    }
+    void OnCollisionEnter(Collision collision) => player.OnCollisionEnter(collision);
     
     void OnCollisionExit(Collision collision) => player.OnCollisionExit(collision);
 }

--- a/Assets/Global/Scripts/Player/PlayerObject.cs.meta
+++ b/Assets/Global/Scripts/Player/PlayerObject.cs.meta
@@ -1,2 +1,2 @@
 fileFormatVersion: 2
-guid: f9235bd2ee59880468e8c5db0a6a3dc8
+guid: da7430b38fabe854bb44c924a4893d76

--- a/Assets/Production/Prefabs/Player.prefab
+++ b/Assets/Production/Prefabs/Player.prefab
@@ -672,7 +672,7 @@ GameObject:
   - component: {fileID: 3283009994523005968}
   - component: {fileID: 7191464586079592423}
   - component: {fileID: 4479891375412012469}
-  - component: {fileID: 4926589023627480149}
+  - component: {fileID: 546042556488619533}
   m_Layer: 0
   m_Name: PlayerObj
   m_TagString: Untagged
@@ -802,7 +802,7 @@ Rigidbody:
   m_Interpolate: 1
   m_Constraints: 112
   m_CollisionDetection: 1
---- !u!114 &4926589023627480149
+--- !u!114 &546042556488619533
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -811,7 +811,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 6841058461259160835}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f9235bd2ee59880468e8c5db0a6a3dc8, type: 3}
+  m_Script: {fileID: 11500000, guid: da7430b38fabe854bb44c924a4893d76, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   player: {fileID: 9169223613212550927}


### PR DESCRIPTION
## Purpose of this PR:
when player jumps on top of an object, make it jump again

## How to test:
Si Wai > JumpOnObject. increase jump force if needed

### links: 
[Ticket](https://github.com/orgs/SillyBusinessInc/projects/1?pane=issue&itemId=86515779&issue=SillyBusinessInc%7CSillyBusinessGame%7C30)  
[Documentation link](https://hrnl.sharepoint.com/:w:/r/sites/GameDesignDevelopment/_layouts/15/Doc.aspx?sourcedoc=%7BE7AE02C4-3CF2-49E8-9A49-653A1A85DC97%7D&file=Technical%20Documentation.docx&action=default&mobileredirect=true)  
