### PR TITLE
feat/#76-unify-input-system : Unified input system / Player state changes

### DIFF
--- a/Assets/Global/Scripts/Player/Player.cs
+++ b/Assets/Global/Scripts/Player/Player.cs
@@ -1,6 +1,5 @@
-using System;
+
 using UnityEngine;
-using UnityEngine.InputSystem;
 using UnityEngine.Serialization;
 
 public class Player : MonoBehaviour
@@ -36,8 +35,7 @@ public class Player : MonoBehaviour
 
     [HideInInspector] public bool canDodgeRoll = true;
     [HideInInspector] public int currentJumps = 0;
-    [HideInInspector] public float horizontalInput;
-    [HideInInspector] public float verticalInput;
+    [HideInInspector] public Vector2 movementInput;
     [HideInInspector] public bool isGrounded;
     [HideInInspector] public bool tailCanDoDamage = false;
     [HideInInspector] public PlayerStates states;
@@ -47,15 +45,11 @@ public class Player : MonoBehaviour
     [Header("Debugging")]
     [SerializeField] private string currentStateName = "none";
 
-    public PlayerInput inputActions;
-    // private PlayerInputActions inputActions;
-
 
     void Start()
     {
         states = new PlayerStates(this);
         SetState(states.Idle);
-        inputActions = GetComponent<PlayerInput>();
         // health and maxHealth should be the same value at the start of game
         playerStatistic.health = playerStatistic.maxHealth.GetValue();
         if (healthBar) healthBar.UpdateHealthBar(0f, playerStatistic.maxHealth.GetValue(), playerStatistic.health);
@@ -100,9 +94,7 @@ public class Player : MonoBehaviour
 
     public Vector3 GetDirection()
     {
-        Vector2 input = inputActions.actions["Move"].ReadValue<Vector2>();
-
-        Vector3 moveDirection = orientation.forward * input.y + orientation.right * input.x;
+        Vector3 moveDirection = orientation.forward * movementInput.y + orientation.right * movementInput.x;
 
         return moveDirection.normalized;
     }

--- a/Assets/Global/Scripts/Player/Player.cs
+++ b/Assets/Global/Scripts/Player/Player.cs
@@ -41,7 +41,7 @@ public class Player : MonoBehaviour
     [HideInInspector] public bool isGrounded;
     [HideInInspector] public bool tailCanDoDamage = false;
     [HideInInspector] public PlayerStates states;
-    private StateBase currentState;
+    public StateBase currentState;
     public Healthbar healthBar;
 
     [Header("Debugging")]
@@ -82,6 +82,7 @@ public class Player : MonoBehaviour
     public void OnCollisionEnter(Collision collision)
     {
         isGrounded = collision.gameObject.CompareTag("Ground");
+        currentJumps = 0;
         currentState.OnCollision(collision);
     }
     public void OnCollisionExit(Collision collision)
@@ -108,7 +109,7 @@ public class Player : MonoBehaviour
 
     private void RotatePlayerObj()
     {
-        
+
         if (rb.linearVelocity.magnitude > 0.1f)
         {
             var direction = Vector3.ProjectOnPlane(rb.linearVelocity, Vector3.up).normalized;

--- a/Assets/Global/Scripts/Player/PlayerOrientation.cs
+++ b/Assets/Global/Scripts/Player/PlayerOrientation.cs
@@ -1,12 +1,9 @@
-using System;
-using Unity.Mathematics;
 using UnityEngine;
-using UnityEngine.InputSystem;
+
 
 public class PlayerOrientation : MonoBehaviour
 {
-    [SerializeField] private Rigidbody playerRb;
-    [SerializeField] private PlayerInput input;
+    [SerializeField] private Player player;
     [SerializeField] private Transform cameraTransform;
 
     private Vector2 _rotation;
@@ -15,19 +12,15 @@ public class PlayerOrientation : MonoBehaviour
     {
         Cursor.lockState = CursorLockMode.Locked;
         Cursor.visible = false;
-        input = GetComponentInParent<PlayerInput>();
     }
 
     private void Update()
     {
-        // Check if the player has pressed the forward movement input
-        Vector2 movementInput = input.actions["Move"].ReadValue<Vector2>();
-
-        if (movementInput.magnitude > 0)
+        if (player.movementInput.magnitude > 0)
         {
             // Align the player with the camera's forward direction if forward movement is initiated
             AlignPlayerWithCamera();
-            transform.position = playerRb.transform.position;
+            transform.position = player.rb.transform.position;
         }
     }
 

--- a/Assets/Global/Scripts/Player/States/AttackingState.cs
+++ b/Assets/Global/Scripts/Player/States/AttackingState.cs
@@ -47,7 +47,7 @@ public class AttackingState : StateBase
         {
             Player.rb.AddForce(Vector3.down * Player.jumpForce, ForceMode.Impulse);
         }
-        Player.SetState(movementInput.magnitude > 0 ? Player.states.Walking : Player.states.Idle);
+        Player.SetState(Player.movementInput.magnitude > 0 ? Player.states.Walking : Player.states.Idle);
     }
     void Slash()
     {
@@ -74,7 +74,7 @@ public class AttackingState : StateBase
             }
             else
             {
-                Player.SetState(movementInput.magnitude > 0 ? Player.states.Walking : Player.states.Idle);
+                Player.SetState(Player.movementInput.magnitude > 0 ? Player.states.Walking : Player.states.Idle);
             }
         }
     }
@@ -117,7 +117,7 @@ public class AttackingState : StateBase
             if (Player.isSlamming)
             {
                 Player.isSlamming = false;
-                Player.SetState(movementInput.magnitude > 0 ? Player.states.Walking : Player.states.Idle);
+                Player.SetState(Player.movementInput.magnitude > 0 ? Player.states.Walking : Player.states.Idle);
             }
         }
     }

--- a/Assets/Global/Scripts/Player/States/AttackingState.cs
+++ b/Assets/Global/Scripts/Player/States/AttackingState.cs
@@ -51,7 +51,7 @@ public class AttackingState : StateBase
         {
             Player.rb.AddForce(Vector3.down * Player.jumpForce, ForceMode.Impulse);
         }
-        Player.SetState(Player.states.Idle);
+        Player.SetState(movementInput.magnitude > 0 ? Player.states.Walking : Player.states.Idle);
     }
     void Slash()
     {
@@ -78,7 +78,7 @@ public class AttackingState : StateBase
             }
             else
             {
-                Player.SetState(Player.states.Idle);
+                Player.SetState(movementInput.magnitude > 0 ? Player.states.Walking : Player.states.Idle);
             }
         }
     }
@@ -121,7 +121,7 @@ public class AttackingState : StateBase
             if (Player.isSlamming)
             {
                 Player.isSlamming = false;
-                Player.SetState(Player.states.Idle);
+                Player.SetState(movementInput.magnitude > 0 ? Player.states.Walking : Player.states.Idle);
             }
         }
     }

--- a/Assets/Global/Scripts/Player/States/AttackingState.cs
+++ b/Assets/Global/Scripts/Player/States/AttackingState.cs
@@ -1,9 +1,5 @@
-using JetBrains.Annotations;
-using NUnit.Framework;
-using System.Data;
-using UnityEditor;
 using UnityEngine;
-using UnityEngine.UIElements;
+
 
 public class AttackingState : StateBase
 {

--- a/Assets/Global/Scripts/Player/States/DodgeRollState.cs
+++ b/Assets/Global/Scripts/Player/States/DodgeRollState.cs
@@ -2,7 +2,7 @@ using UnityEngine;
 
 public class DodgeRollState : StateBase
 {
-    
+
     private float timer;
 
     public DodgeRollState(Player player) : base(player)
@@ -12,15 +12,15 @@ public class DodgeRollState : StateBase
     public override void Enter()
     {
         Vector3 dodgeDirection = Player.GetDirection();
-        
+
         timer = Player.dodgeRollDuration;
         Player.canDodgeRoll = false;
-        
+
         if (dodgeDirection == Vector3.zero)
         {
             dodgeDirection = Player.rb.transform.forward.normalized;
         }
-        
+
         Player.rb.AddForce(dodgeDirection * Player.dodgeRollSpeed, ForceMode.Impulse);
         // player.animator.SetTrigger("DodgeRoll");
     }
@@ -33,7 +33,7 @@ public class DodgeRollState : StateBase
         {
             if (Player.isGrounded)
             {
-                Player.SetState(Player.states.Idle);
+                Player.SetState(movementInput.magnitude > 0 ? Player.states.Walking : Player.states.Idle);
             }
             else
             {

--- a/Assets/Global/Scripts/Player/States/DodgeRollState.cs
+++ b/Assets/Global/Scripts/Player/States/DodgeRollState.cs
@@ -33,7 +33,7 @@ public class DodgeRollState : StateBase
         {
             if (Player.isGrounded)
             {
-                Player.SetState(movementInput.magnitude > 0 ? Player.states.Walking : Player.states.Idle);
+                Player.SetState(Player.movementInput.magnitude > 0 ? Player.states.Walking : Player.states.Idle);
             }
             else
             {

--- a/Assets/Global/Scripts/Player/States/FallingState.cs
+++ b/Assets/Global/Scripts/Player/States/FallingState.cs
@@ -1,4 +1,3 @@
-using Unity.VisualScripting;
 using UnityEngine;
 using UnityEngine.InputSystem;
 

--- a/Assets/Global/Scripts/Player/States/FallingState.cs
+++ b/Assets/Global/Scripts/Player/States/FallingState.cs
@@ -1,3 +1,4 @@
+using Unity.VisualScripting;
 using UnityEngine;
 using UnityEngine.InputSystem;
 
@@ -5,68 +6,34 @@ public class FallingState : StateBase
 {
     public FallingState(Player player) : base(player) { }
 
-    public override void Enter()
-    {
-        // Subscribe to input action events for Jump, Glide, Dodge, and Attack
-        Player.inputActions.actions["Glide"].performed += OnGlide;
-        Player.inputActions.actions["Jump"].performed += OnJump;
-        Player.inputActions.actions["Dodge"].performed += OnDodge;
-        Player.inputActions.actions["Attack"].performed += OnAttack;
-    }
-
-    public override void Exit()
-    {
-        // Unsubscribe from input action events to avoid multiple subscriptions
-        Player.inputActions.actions["Glide"].performed -= OnGlide;
-        Player.inputActions.actions["Jump"].performed -= OnJump;
-        Player.inputActions.actions["Dodge"].performed -= OnDodge;
-        Player.inputActions.actions["Attack"].performed -= OnAttack;
-    }
-
     public override void Update()
     {
         // Apply horizontal movement in the air
         Player.rb.AddForce(Player.GetDirection() * (Player.playerStatistic.speed * Player.airBornMovementFactor), ForceMode.Force);
     }
 
-    private void OnJump(InputAction.CallbackContext context)
+    public override void Jump(InputAction.CallbackContext ctx)
     {
-        if (Player.doubleJumps > Player.currentJumps)
+        if (ctx.started && Player.doubleJumps > Player.currentJumps)
         {
-            Player.SetState(Player.states.Jumping);
             Player.currentJumps += 1;
+            Player.SetState(Player.states.Jumping);
         }
     }
 
-    private void OnGlide(InputAction.CallbackContext context)
+    public override void Glide(InputAction.CallbackContext ctx)
     {
-        // if (Player.rb.linearVelocity.y < 0 && Player.canDodgeRoll)
-        // {
-        Player.SetState(Player.states.Gliding);
-        // }
-    }
-
-    private void OnDodge(InputAction.CallbackContext context)
-    {
-        if (Player.canDodgeRoll)
+        if (ctx.performed && Player.rb.linearVelocity.y < 0)
         {
-            Player.SetState(Player.states.DodgeRoll);
+            Player.SetState(Player.states.Gliding);
         }
-    }
-
-    private void OnAttack(InputAction.CallbackContext context)
-    {
-        Player.attackCounter = 2;
-        Player.isSlamming = true;
-        Player.SetState(Player.states.Attacking);
     }
 
     public override void OnCollision(Collision collision)
     {
         if (collision.gameObject.CompareTag("Ground"))
         {
-            Player.SetState(Player.states.Idle);
-            Player.currentJumps = 0;
+            Player.SetState(movementInput.magnitude > 0 ? Player.states.Walking : Player.states.Idle);
         }
     }
 }

--- a/Assets/Global/Scripts/Player/States/FallingState.cs
+++ b/Assets/Global/Scripts/Player/States/FallingState.cs
@@ -8,7 +8,7 @@ public class FallingState : StateBase
     public override void Update()
     {
         // Apply horizontal movement in the air
-        Player.rb.AddForce(Player.GetDirection() * (Player.playerStatistic.speed * Player.airBornMovementFactor), ForceMode.Force);
+        Player.rb.AddForce(Player.GetDirection() * (Player.playerStatistic.speed * Player.airBornMovementFactor), ForceMode.Acceleration);
     }
 
     public override void Jump(InputAction.CallbackContext ctx)
@@ -32,7 +32,7 @@ public class FallingState : StateBase
     {
         if (collision.gameObject.CompareTag("Ground"))
         {
-            Player.SetState(movementInput.magnitude > 0 ? Player.states.Walking : Player.states.Idle);
+            Player.SetState(Player.movementInput.magnitude > 0 ? Player.states.Walking : Player.states.Idle);
         }
     }
 }

--- a/Assets/Global/Scripts/Player/States/GlidingState.cs
+++ b/Assets/Global/Scripts/Player/States/GlidingState.cs
@@ -1,5 +1,4 @@
 using UnityEngine;
-using UnityEngine.InputSystem;
 
 public class GlidingState : StateBase
 {
@@ -10,24 +9,6 @@ public class GlidingState : StateBase
     public override void Update()
     {
         Player.rb.AddForce(Player.GetDirection() * Player.playerStatistic.speed, ForceMode.Force);
-
-
-        if (Player.inputActions.actions["Jump"].triggered && Player.doubleJumps > Player.currentJumps && Player.canDodgeRoll)
-        {
-            Player.SetState(Player.states.Jumping);
-            Player.currentJumps += 1;
-        }
-
-        if (Player.inputActions.actions["Dodge"].triggered && Player.canDodgeRoll)
-        {
-            Player.SetState(Player.states.DodgeRoll);
-        }
-        if (Input.GetMouseButtonDown(0)) // TODO: replace this with the new event system thing
-        {
-            Player.attackCounter = 2;
-            Player.isSlamming = true;
-            Player.SetState(Player.states.Attacking);
-        }
     }
 
     public override void Enter()

--- a/Assets/Global/Scripts/Player/States/GlidingState.cs
+++ b/Assets/Global/Scripts/Player/States/GlidingState.cs
@@ -8,7 +8,7 @@ public class GlidingState : StateBase
     }
     public override void Update()
     {
-        Player.rb.AddForce(Player.GetDirection() * Player.playerStatistic.speed, ForceMode.Force);
+        Player.rb.AddForce(Player.GetDirection() * Player.playerStatistic.speed, ForceMode.Acceleration);
     }
 
     public override void Enter()
@@ -26,7 +26,7 @@ public class GlidingState : StateBase
     {
         if (collision.gameObject.CompareTag("Ground"))
         {
-            Player.SetState(movementInput.magnitude > 0 ? Player.states.Walking : Player.states.Idle);
+            Player.SetState(Player.movementInput.magnitude > 0 ? Player.states.Walking : Player.states.Idle);
         }
     }
 }

--- a/Assets/Global/Scripts/Player/States/GlidingState.cs
+++ b/Assets/Global/Scripts/Player/States/GlidingState.cs
@@ -9,22 +9,16 @@ public class GlidingState : StateBase
     }
     public override void Update()
     {
-        if (Player.inputActions.actions["Glide"].ReadValue<float>() == 0)
-        {
-            Player.SetState(Player.states.Falling);  // When movement ends (e.g., released)
-        }
-
-        
         Player.rb.AddForce(Player.GetDirection() * Player.playerStatistic.speed, ForceMode.Force);
 
-        
-        if(Player.inputActions.actions["Jump"].triggered && Player.doubleJumps > Player.currentJumps && Player.canDodgeRoll)
+
+        if (Player.inputActions.actions["Jump"].triggered && Player.doubleJumps > Player.currentJumps && Player.canDodgeRoll)
         {
             Player.SetState(Player.states.Jumping);
             Player.currentJumps += 1;
         }
 
-        if(Player.inputActions.actions["Dodge"].triggered && Player.canDodgeRoll)
+        if (Player.inputActions.actions["Dodge"].triggered && Player.canDodgeRoll)
         {
             Player.SetState(Player.states.DodgeRoll);
         }
@@ -51,8 +45,7 @@ public class GlidingState : StateBase
     {
         if (collision.gameObject.CompareTag("Ground"))
         {
-            Player.SetState(Player.states.Idle);
-            Player.currentJumps = 0;
+            Player.SetState(movementInput.magnitude > 0 ? Player.states.Walking : Player.states.Idle);
         }
     }
 }

--- a/Assets/Global/Scripts/Player/States/IdleState.cs
+++ b/Assets/Global/Scripts/Player/States/IdleState.cs
@@ -9,28 +9,10 @@ public class IdleState : StateBase
 
     public override void Update()
     {
-        
-        if (Player.inputActions.actions["Move"].ReadValue<Vector2>() != Vector2.zero)
-        {
-            Player.SetState(Player.states.Walking);
-        }
-
-        if (Player.inputActions.actions["Jump"].triggered)
-        {
-            Player.SetState(Player.states.Jumping);
-        }
         if (!Player.isGrounded)
         {
             Player.SetState(Player.states.Falling);
         }
-
-        if (Input.GetMouseButtonDown(0)) // TODO: replace this with the new event system thing
-        {
-            Player.SetState(Player.states.Attacking);
-        }
-        if (Player.inputActions.actions["Dodge"].triggered && Player.canDodgeRoll)
-        {
-            Player.SetState(Player.states.DodgeRoll);
-        }
     }
+
 }

--- a/Assets/Global/Scripts/Player/States/IdleState.cs
+++ b/Assets/Global/Scripts/Player/States/IdleState.cs
@@ -1,5 +1,3 @@
-using UnityEngine;
-
 public class IdleState : StateBase
 {
     public IdleState(Player player) : base(player)

--- a/Assets/Global/Scripts/Player/States/JumpingState.cs
+++ b/Assets/Global/Scripts/Player/States/JumpingState.cs
@@ -5,15 +5,12 @@ public class JumpingState : StateBase
     public JumpingState(Player player) : base(player)
     {
     }
-    
+
     public override void Update()
     {
         Player.rb.linearVelocity = new Vector3(Player.rb.linearVelocity.x, 0, Player.rb.linearVelocity.z);
         Player.rb.AddForce(Vector3.up * Player.jumpForce, ForceMode.Impulse);
+
         Player.SetState(Player.states.Falling);
-        if(Player.inputActions.actions["Dodge"].triggered && Player.canDodgeRoll)
-        {
-            Player.SetState(Player.states.DodgeRoll);
-        }
     }
 }

--- a/Assets/Global/Scripts/Player/States/StateBase.cs
+++ b/Assets/Global/Scripts/Player/States/StateBase.cs
@@ -37,7 +37,6 @@ public abstract class StateBase
     }
 
     // Input handling
-
     public virtual void Move(InputAction.CallbackContext ctx)
     {
         movementInput = ctx.ReadValue<Vector2>();

--- a/Assets/Global/Scripts/Player/States/StateBase.cs
+++ b/Assets/Global/Scripts/Player/States/StateBase.cs
@@ -4,7 +4,6 @@ using UnityEngine.InputSystem;
 public abstract class StateBase
 {
     protected readonly Player Player;
-    protected Vector2 movementInput;
 
     protected StateBase(Player player)
     {
@@ -39,7 +38,7 @@ public abstract class StateBase
     // Input handling
     public virtual void Move(InputAction.CallbackContext ctx)
     {
-        movementInput = ctx.ReadValue<Vector2>();
+        Player.movementInput = ctx.ReadValue<Vector2>();
         if (ctx.performed && Player.currentState != Player.states.Walking)
         {
             Player.SetState(Player.states.Walking);

--- a/Assets/Global/Scripts/Player/States/StateBase.cs
+++ b/Assets/Global/Scripts/Player/States/StateBase.cs
@@ -1,8 +1,10 @@
 using UnityEngine;
+using UnityEngine.InputSystem;
 
 public abstract class StateBase
 {
     protected readonly Player Player;
+    protected Vector2 movementInput;
 
     protected StateBase(Player player)
     {
@@ -32,5 +34,67 @@ public abstract class StateBase
     public virtual void OnCollision(Collision collision)
     {
 
+    }
+
+    // Input handling
+
+    public virtual void Move(InputAction.CallbackContext ctx)
+    {
+        movementInput = ctx.ReadValue<Vector2>();
+        if (ctx.performed && Player.currentState != Player.states.Walking)
+        {
+            Player.SetState(Player.states.Walking);
+        }
+    }
+
+    public virtual void Sprint(InputAction.CallbackContext ctx)
+    {
+
+    }
+
+    public virtual void Dodge(InputAction.CallbackContext ctx)
+    {
+        if (ctx.started)
+        {
+            if (Player.canDodgeRoll)
+            {
+                Player.SetState(Player.states.DodgeRoll);
+            }
+        }
+    }
+
+    public virtual void Jump(InputAction.CallbackContext ctx)
+    {
+        if (ctx.started)
+        {
+            Player.SetState(Player.states.Jumping);
+        }
+
+    }
+
+    public virtual void Glide(InputAction.CallbackContext ctx)
+    {
+        if (ctx.canceled)
+        {
+            Player.SetState(Player.states.Falling);
+        }
+    }
+
+    public virtual void Crouch(InputAction.CallbackContext ctx)
+    {
+
+    }
+
+    public virtual void Attack(InputAction.CallbackContext ctx)
+    {
+        if (ctx.started)
+        {
+            if (!Player.isGrounded)
+            {
+                Player.attackCounter = 2;
+                Player.isSlamming = true;
+            }
+            Player.SetState(Player.states.Attacking);
+        }
     }
 }

--- a/Assets/Global/Scripts/Player/States/WalkingState.cs
+++ b/Assets/Global/Scripts/Player/States/WalkingState.cs
@@ -12,28 +12,10 @@ public class WalkingState : StateBase
     {
         // add force to the player object for movement
         Player.rb.AddForce(Player.GetDirection() * Player.playerStatistic.speed, ForceMode.Acceleration);
-        if (Player.inputActions.actions["Move"].ReadValue<Vector2>() == Vector2.zero)
-        {
-            Player.SetState(Player.states.Idle);
-        }
-
-        if (Player.inputActions.actions["Jump"].triggered)
-        {
-            Player.SetState(Player.states.Jumping);
-        }
-
         if (!Player.isGrounded)
         {
             Player.SetState(Player.states.Falling);
         }
-        if (Input.GetMouseButtonDown(0)) // TODO: replace this with the new event system thing
-        {
-            Player.SetState(Player.states.Attacking);
-        }
-        if (Player.inputActions.actions["Dodge"].triggered && Player.canDodgeRoll)
-        {
-            Player.SetState(Player.states.DodgeRoll);
-        }
-
     }
+
 }

--- a/Assets/Global/Scripts/Player/States/WalkingState.cs
+++ b/Assets/Global/Scripts/Player/States/WalkingState.cs
@@ -1,5 +1,4 @@
 using UnityEngine;
-using UnityEngine.InputSystem;
 
 public class WalkingState : StateBase
 {

--- a/Assets/Global/Scripts/Reference/GlobalReference.cs
+++ b/Assets/Global/Scripts/Reference/GlobalReference.cs
@@ -1,9 +1,5 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using UnityEngine;
 using UnityEngine.Events;
-using UnityEngine.InputSystem.Utilities;
 
 public static class GlobalReference
 {
@@ -21,29 +17,35 @@ public static class GlobalReference
     // GameObject reference logic
     public static Dictionary<string, Reference> referenceList = new();
 
-    public static void RegisterReference(Reference ref_) {
-        if (!ref_) {
+    public static void RegisterReference(Reference ref_)
+    {
+        if (!ref_)
+        {
             // Debug.LogWarning("Could not register object because no reference was given");
             return;
         }
 
         string name = ref_.GetType().Name;
-        if (referenceList.ContainsKey(name)) {
+        if (referenceList.ContainsKey(name))
+        {
             // Debug.LogError($"{name} is already assigned and can not be assigned multiple times. Please ensure there is only one {name} in this scene");
             return;
         }
 
-        referenceList.Add(name ,ref_);
+        referenceList.Add(name, ref_);
     }
 
-    public static void UnregisterReference(Reference ref_) {
-        if (!ref_) {
+    public static void UnregisterReference(Reference ref_)
+    {
+        if (!ref_)
+        {
             // Debug.LogWarning("Could not unregister object because no reference was given");
             return;
         }
 
         string name = ref_.GetType().Name;
-        if (!referenceList.ContainsKey(name)) {
+        if (!referenceList.ContainsKey(name))
+        {
             // Debug.LogWarning($"{name} cannot be unassigned because it has not been assigned in the first place");
             return;
         }
@@ -55,7 +57,8 @@ public static class GlobalReference
     /// <para>Finds the reference defined by the given generic type.</para>
     /// <para>Never use this method in Awake() or in OnDestroy()</para>
     /// </summary>
-    public static T GetReference<T>() {
+    public static T GetReference<T>()
+    {
         string name = typeof(T).Name;
         if (referenceList.ContainsKey(name) && referenceList[name] is T t) return t;
         return default;
@@ -64,22 +67,26 @@ public static class GlobalReference
     // Event Logic
     public static Dictionary<Events, UnityEvent> eventList = new();
 
-    public static void SubscribeTo(Events eventName, UnityAction action) {
+    public static void SubscribeTo(Events eventName, UnityAction action)
+    {
         // Debug.Log($"Object Subscribed ({eventName})");
         TryGetEvent(eventName).AddListener(action);
     }
 
-    public static void UnsubscribeTo(Events eventName, UnityAction action) {
+    public static void UnsubscribeTo(Events eventName, UnityAction action)
+    {
         // Debug.Log($"Object Unsubscribed ({eventName})");
         TryGetEvent(eventName).RemoveListener(action);
     }
 
-    public static void AttemptInvoke(Events eventName) {
+    public static void AttemptInvoke(Events eventName)
+    {
         // Debug.Log($"Object Invoked ({eventName})");
         TryGetEvent(eventName).Invoke();
     }
 
-    private static UnityEvent TryGetEvent(Events eventName) {
+    private static UnityEvent TryGetEvent(Events eventName)
+    {
         return eventList.ContainsKey(eventName) ? eventList[eventName] : eventList[eventName] = new();
     }
 }

--- a/Assets/PlayerInputHandler.cs
+++ b/Assets/PlayerInputHandler.cs
@@ -1,0 +1,43 @@
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+public class PlayerInputHandler : MonoBehaviour
+{
+    [SerializeField] private Player player;
+
+    // Handling the Input for the player.
+    public void OnMove(InputAction.CallbackContext ctx)
+    {
+        player.currentState.Move(ctx);
+    }
+
+    public void OnAttack(InputAction.CallbackContext ctx)
+    {
+        player.currentState.Attack(ctx);
+    }
+
+    public void OnCrouch(InputAction.CallbackContext ctx)
+    {
+        player.currentState.Crouch(ctx);
+    }
+
+    public void OnSprint(InputAction.CallbackContext ctx)
+    {
+        player.currentState.Sprint(ctx);
+    }
+
+    public void OnGlide(InputAction.CallbackContext ctx)
+    {
+        player.currentState.Glide(ctx);
+    }
+
+    public void OnJump(InputAction.CallbackContext ctx)
+    {
+        player.currentState.Jump(ctx);
+    }
+
+    public void OnDodge(InputAction.CallbackContext ctx)
+    {
+        player.currentState.Dodge(ctx);
+    }
+}

--- a/Assets/PlayerInputHandler.cs.meta
+++ b/Assets/PlayerInputHandler.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4259e883feafc8a45909814848e51033

--- a/Assets/Production/Prefabs/Player.prefab
+++ b/Assets/Production/Prefabs/Player.prefab
@@ -77,13 +77,11 @@ MonoBehaviour:
   activeAttackCooldown: 0
   canDodgeRoll: 1
   currentJumps: 0
-  horizontalInput: 0
-  verticalInput: 0
+  movementInput: {x: 0, y: 0}
   isGrounded: 0
   tailCanDoDamage: 0
   healthBar: {fileID: 0}
   currentStateName: none
-  inputActions: {fileID: 2974869042834182435}
 --- !u!114 &2974869042834182435
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -914,8 +912,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 785e70c0a23a3ca4ba305b9841196530, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  playerRb: {fileID: 8218035431276073872}
-  input: {fileID: 2974869042834182435}
+  player: {fileID: 9169223613212550927}
   cameraTransform: {fileID: 6505893237244659488}
 --- !u!1 &5867138334220634699
 GameObject:

--- a/Assets/Production/Prefabs/Player.prefab
+++ b/Assets/Production/Prefabs/Player.prefab
@@ -12,9 +12,10 @@ GameObject:
   - component: {fileID: 9169223613212550927}
   - component: {fileID: 2974869042834182435}
   - component: {fileID: 29515307043888343}
+  - component: {fileID: 1671110380266321935}
   m_Layer: 0
   m_Name: Player
-  m_TagString: Untagged
+  m_TagString: Player
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -96,7 +97,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Actions: {fileID: -944628639613478452, guid: 052faaac586de48259a63d0c4782560b, type: 3}
-  m_NotificationBehavior: 0
+  m_NotificationBehavior: 2
   m_UIInputModule: {fileID: 0}
   m_DeviceLostEvent:
     m_PersistentCalls:
@@ -107,11 +108,181 @@ MonoBehaviour:
   m_ControlsChangedEvent:
     m_PersistentCalls:
       m_Calls: []
-  m_ActionEvents: []
+  m_ActionEvents:
+  - m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1671110380266321935}
+        m_TargetAssemblyTypeName: PlayerInputHandler, Assembly-CSharp
+        m_MethodName: OnMove
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_ActionId: 351f2ccd-1f9f-44bf-9bec-d62ac5c5f408
+    m_ActionName: 'Player/Move[/Keyboard/w,/Keyboard/upArrow,/Keyboard/s,/Keyboard/downArrow,/Keyboard/a,/Keyboard/leftArrow,/Keyboard/d,/Keyboard/rightArrow,/Thrustmaster
+      T.16000M/stick]'
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 6b444451-8a00-4d00-a97e-f47457f736a8
+    m_ActionName: 'Player/Look[/Mouse/delta,/Pen/delta]'
+  - m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1671110380266321935}
+        m_TargetAssemblyTypeName: PlayerInputHandler, Assembly-CSharp
+        m_MethodName: OnAttack
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_ActionId: 6c2ab1b8-8984-453a-af3d-a3c78ae1679a
+    m_ActionName: 'Player/Attack[/Mouse/leftButton,/Thrustmaster T.16000M/trigger,/Keyboard/enter]'
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 852140f2-7766-474d-8707-702459ba45f3
+    m_ActionName: 'Player/Interact[/Keyboard/e]'
+  - m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1671110380266321935}
+        m_TargetAssemblyTypeName: PlayerInputHandler, Assembly-CSharp
+        m_MethodName: OnCrouch
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_ActionId: 27c5f898-bc57-4ee1-8800-db469aca5fe3
+    m_ActionName: 'Player/Crouch[/Keyboard/c]'
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 2776c80d-3c14-4091-8c56-d04ced07a2b0
+    m_ActionName: 'Player/Previous[/Keyboard/1]'
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: b7230bb6-fc9b-4f52-8b25-f5e19cb2c2ba
+    m_ActionName: 'Player/Next[/Keyboard/2]'
+  - m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1671110380266321935}
+        m_TargetAssemblyTypeName: PlayerInputHandler, Assembly-CSharp
+        m_MethodName: OnSprint
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_ActionId: 641cd816-40e6-41b4-8c3d-04687c349290
+    m_ActionName: 'Player/Sprint[/Keyboard/leftShift]'
+  - m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1671110380266321935}
+        m_TargetAssemblyTypeName: PlayerInputHandler, Assembly-CSharp
+        m_MethodName: OnGlide
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_ActionId: 17e61bdc-a060-44b9-8eb5-fae4199a3c88
+    m_ActionName: 'Player/Glide[/Keyboard/c]'
+  - m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1671110380266321935}
+        m_TargetAssemblyTypeName: PlayerInputHandler, Assembly-CSharp
+        m_MethodName: OnJump
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_ActionId: f1ba0d36-48eb-4cd5-b651-1c94a6531f70
+    m_ActionName: 'Player/Jump[/Keyboard/space]'
+  - m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1671110380266321935}
+        m_TargetAssemblyTypeName: PlayerInputHandler, Assembly-CSharp
+        m_MethodName: OnDodge
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_ActionId: f1129072-a663-4be6-9b0c-9a0c91afe6f1
+    m_ActionName: 'Player/Dodge[/Keyboard/ctrl]'
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: c95b2375-e6d9-4b88-9c4c-c5e76515df4b
+    m_ActionName: 'UI/Navigate[/Thrustmaster T.16000M/stick/up,/Thrustmaster T.16000M/stick/down,/Thrustmaster
+      T.16000M/stick/left,/Thrustmaster T.16000M/stick/right,/Keyboard/w,/Keyboard/upArrow,/Keyboard/s,/Keyboard/downArrow,/Keyboard/a,/Keyboard/leftArrow,/Keyboard/d,/Keyboard/rightArrow]'
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 7607c7b6-cd76-4816-beef-bd0341cfe950
+    m_ActionName: 'UI/Submit[/Keyboard/enter]'
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 15cef263-9014-4fd5-94d9-4e4a6234a6ef
+    m_ActionName: 'UI/Cancel[/Keyboard/escape]'
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 32b35790-4ed0-4e9a-aa41-69ac6d629449
+    m_ActionName: 'UI/Point[/Mouse/position,/Pen/position]'
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 3c7022bf-7922-4f7c-a998-c437916075ad
+    m_ActionName: 'UI/Click[/Mouse/leftButton,/Pen/tip]'
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 44b200b1-1557-4083-816c-b22cbdf77ddf
+    m_ActionName: 'UI/RightClick[/Mouse/rightButton]'
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: dad70c86-b58c-4b17-88ad-f5e53adf419e
+    m_ActionName: 'UI/MiddleClick[/Mouse/middleButton]'
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 0489e84a-4833-4c40-bfae-cea84b696689
+    m_ActionName: 'UI/ScrollWheel[/Mouse/scroll]'
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 24908448-c609-4bc3-a128-ea258674378a
+    m_ActionName: UI/TrackedDevicePosition
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 9caa3d8a-6b2f-4e8e-8bad-6ede561bd9be
+    m_ActionName: UI/TrackedDeviceOrientation
   m_NeverAutoSwitchControlSchemes: 0
   m_DefaultControlScheme: 
   m_DefaultActionMap: Player
-  m_SplitScreenIndex: -1
+  m_SplitScreenIndex: 0
   m_Camera: {fileID: 0}
 --- !u!114 &29515307043888343
 MonoBehaviour:
@@ -125,6 +296,19 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6197816e955f0db409561e705c307c76, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &1671110380266321935
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 637936633501757367}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4259e883feafc8a45909814848e51033, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  player: {fileID: 9169223613212550927}
 --- !u!1 &773626285719660731
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
## Purpose of this PR:
This PR aims to unify all of our (player) input handling. Using the Actions + PlayerInput Component workflow documentated here: https://docs.unity3d.com/Packages/com.unity.inputsystem@1.5/manual/Workflow-PlayerInput.html

To achieve this there's substantial changes to the Player's BaseState, and the various already implemented player states.

## How to test:
This change is contained to the player prefab, therefore it can be tested in any scene with this prefab in it.
Test out that all movement / input works as expected, and works as the old behaviours.

### links: 
closes #76
