### PR TITLE
Fix:#128 enemy gets hit twice

### DIFF
--- a/Assets/Dev/Salah/MovementScene.unity
+++ b/Assets/Dev/Salah/MovementScene.unity
@@ -212,6 +212,63 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &353647995
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2983649851661643625, guid: 092a25468af9247448566d920992a541, type: 3}
+      propertyPath: m_Name
+      value: Enemy 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4649877972386002139, guid: 092a25468af9247448566d920992a541, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 413.59933
+      objectReference: {fileID: 0}
+    - target: {fileID: 4649877972386002139, guid: 092a25468af9247448566d920992a541, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.99999905
+      objectReference: {fileID: 0}
+    - target: {fileID: 4649877972386002139, guid: 092a25468af9247448566d920992a541, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 673.0869
+      objectReference: {fileID: 0}
+    - target: {fileID: 4649877972386002139, guid: 092a25468af9247448566d920992a541, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4649877972386002139, guid: 092a25468af9247448566d920992a541, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4649877972386002139, guid: 092a25468af9247448566d920992a541, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4649877972386002139, guid: 092a25468af9247448566d920992a541, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4649877972386002139, guid: 092a25468af9247448566d920992a541, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4649877972386002139, guid: 092a25468af9247448566d920992a541, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4649877972386002139, guid: 092a25468af9247448566d920992a541, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 092a25468af9247448566d920992a541, type: 3}
 --- !u!1 &356505944
 GameObject:
   m_ObjectHideFlags: 0
@@ -563,15 +620,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4811859323897289456, guid: f39688a7a7366934c95fc24f9dd976ea, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 428.04
+      value: 411.35
       objectReference: {fileID: 0}
     - target: {fileID: 4811859323897289456, guid: f39688a7a7366934c95fc24f9dd976ea, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 11.74
+      value: 1.4
       objectReference: {fileID: 0}
     - target: {fileID: 4811859323897289456, guid: f39688a7a7366934c95fc24f9dd976ea, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 673
+      value: 672.94
       objectReference: {fileID: 0}
     - target: {fileID: 4811859323897289456, guid: f39688a7a7366934c95fc24f9dd976ea, type: 3}
       propertyPath: m_LocalRotation.w
@@ -1051,3 +1108,4 @@ SceneRoots:
   - {fileID: 1826670407}
   - {fileID: 1978057125}
   - {fileID: 1879681040}
+  - {fileID: 353647995}

--- a/Assets/Global/Scripts/Player/Player.cs
+++ b/Assets/Global/Scripts/Player/Player.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using UnityEngine.Serialization;
 using UnityEngine.UIElements;
-
+using System.Collections.Generic;
 public class Player : MonoBehaviour
 {
     [Header("Settings")]
@@ -21,7 +21,6 @@ public class Player : MonoBehaviour
     public int slamDamage = 10;
     public int firstTailDamage = 10;
     public int secondTailDamage = 15;
-
     public float slamForce = 2.0f;
     public BoxCollider TransformTail;
 
@@ -69,6 +68,10 @@ public class Player : MonoBehaviour
 
     [HideInInspector]
     public Vector2 movementInput;
+
+    [HideInInspector]
+
+    public List<Collider> collidersEnemy;
     public Healthbar healthBar;
 
     [Header("Debugging")]
@@ -84,7 +87,7 @@ public class Player : MonoBehaviour
         states = new PlayerStates(this);
         SetState(states.Idle);
         // health and maxHealth should be the same value at the start of game
-
+        collidersEnemy = new List<Collider>();
         playerStatistic.Health = playerStatistic.MaxHealth.GetValue();
         if (healthBar) healthBar.UpdateHealthBar(0f, playerStatistic.MaxHealth.GetValue(), playerStatistic.Health);
 

--- a/Assets/Global/Scripts/Player/States/AttackingState.cs
+++ b/Assets/Global/Scripts/Player/States/AttackingState.cs
@@ -122,6 +122,7 @@ public class AttackingState : StateBase
 
     public override void Exit()
     {
+        Player.collidersEnemy.Clear();
         Player.tailCanDoDamage = false;
         Player.slamCanDoDamage = false;
         Player.isSlamming = false;

--- a/Assets/Global/Scripts/Player/Tail.cs
+++ b/Assets/Global/Scripts/Player/Tail.cs
@@ -5,27 +5,15 @@ public class Tail : MonoBehaviour
 {
     public Player player;
 
-    private List<Collider> colliders;
-    public void Start()
-    {
-        colliders = new List<Collider>();
-    }
-    public void Update()
-    {
-        colliders = player.tailCanDoDamage? colliders : new List<Collider>();
-    }
     public void OnTriggerEnter(Collider Collider)
     {
         if (Collider.gameObject.CompareTag("Enemy"))
         {
-            if(!colliders.Contains(Collider))
-            {
-                colliders.Add(Collider);
-            }
-            else
+            if(player.collidersEnemy.Contains(Collider))
             {
                 return;
             }
+            player.collidersEnemy.Add(Collider);
             if(player.tailCanDoDamage)
             {
                 float actualDamage = player.tailDoDamage * player.playerStatistic.AttackDamageMultiplier.GetValue();

--- a/Assets/Global/Scripts/Player/Tail.cs
+++ b/Assets/Global/Scripts/Player/Tail.cs
@@ -1,14 +1,31 @@
 using System;
 using UnityEngine;
-
+using System.Collections.Generic;
 public class Tail : MonoBehaviour
 {
     public Player player;
 
+    private List<Collider> colliders;
+    public void Start()
+    {
+        colliders = new List<Collider>();
+    }
+    public void Update()
+    {
+        colliders = player.tailCanDoDamage? colliders : new List<Collider>();
+    }
     public void OnTriggerEnter(Collider Collider)
     {
         if (Collider.gameObject.CompareTag("Enemy"))
         {
+            if(!colliders.Contains(Collider))
+            {
+                colliders.Add(Collider);
+            }
+            else
+            {
+                return;
+            }
             if(player.tailCanDoDamage)
             {
                 float actualDamage = player.tailDoDamage * player.playerStatistic.AttackDamageMultiplier.GetValue();


### PR DESCRIPTION
## Purpose of this PR:
If a tail would attack it would sometimes collide with a player more than once and the player would get attack multiple times

## How to test:
Put a enemy right next player so the tail can go past a enemy more than once, a enemy should only get hit once now

### links: 
[Ticket](https://github.com/SillyBusinessInc/SillyBusinessGame/issues/128)
