### PR TITLE
Fix: Player can't double jump after slamming

### DIFF
--- a/Assets/Global/Scripts/Player/Player.cs
+++ b/Assets/Global/Scripts/Player/Player.cs
@@ -90,6 +90,7 @@ public class Player : MonoBehaviour
 
     void Update()
     {
+        currentJumps = isGrounded ? 0 : currentJumps;
         RaycastDown();
         currentState.Update();
         RotatePlayerObj();

--- a/Assets/Global/Scripts/Player/Player.cs
+++ b/Assets/Global/Scripts/Player/Player.cs
@@ -90,7 +90,6 @@ public class Player : MonoBehaviour
 
     void Update()
     {
-        currentJumps = isGrounded ? 0 : currentJumps;
         RaycastDown();
         currentState.Update();
         RotatePlayerObj();
@@ -144,6 +143,7 @@ public class Player : MonoBehaviour
                 {
                     if (Vector3.Angle(Vector3.up, hit.normal) < degreesToRotate)
                     {
+                        currentJumps = 0;
                         isGrounded = true;
                         return;
                     }

--- a/Assets/Global/Scripts/Player/States/FallingState.cs
+++ b/Assets/Global/Scripts/Player/States/FallingState.cs
@@ -9,6 +9,10 @@ public class FallingState : StateBase
     {
         // Apply horizontal movement in the air
         Player.rb.AddForce(Player.GetDirection() * (Player.playerStatistic.Speed.GetValue() * Player.airBornMovementFactor), ForceMode.Acceleration);
+        if(Player.isGrounded)
+        {
+            Player.SetState(Player.movementInput.magnitude > 0 ? Player.states.Walking : Player.states.Idle);
+        }
     }
 
     public override void Jump(InputAction.CallbackContext ctx)
@@ -25,15 +29,6 @@ public class FallingState : StateBase
         if (ctx.performed && Player.rb.linearVelocity.y < 0)
         {
             Player.SetState(Player.states.Gliding);
-        }
-    }
-
-    public override void OnCollision(Collision collision)
-    {
-        if (Player.isGrounded)
-        {
-            Player.currentJumps = 0;
-            Player.SetState(Player.movementInput.magnitude > 0 ? Player.states.Walking : Player.states.Idle);
         }
     }
 }


### PR DESCRIPTION
## Purpose of this PR:
When you used to be in the air and slammed you could only jump once after landing on the air now this problem is fixed

## How to test:
Get in air and then attack, after that jump as much as you can, you should be able to double jump
**(only required for FEAT and FIX tickets)**

### links: 
[Ticket](https://github.com/SillyBusinessInc/SillyBusinessGame/issues/131) 
